### PR TITLE
Made EventType PartialEq, bumped error-chain version to remove warning.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT / Apache-2.0"
 
 [dependencies]
 bitflags = "1.0"
-error-chain = "0.11"
+error-chain = "0.12"
 libc = "0.2"
 nix = "0.10"
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 
 rust-gpio-cdev is a Rust library/crate providing access to [GPIO character device
 ABI](https://www.kernel.org/doc/Documentation/ABI/testing/gpio-cdev).  This API,
-stabilized with Linux v4.4, deprecates the legacy sysfs interface to GPIOs that
-is now deprecated and is planned to be removed from the upstream kernel after
+stabilized with Linux v4.4, deprecates the legacy sysfs interface to GPIOs that is 
+planned to be removed from the upstream kernel after
 year 2020 (which is coming up quickly).
 
 ## Sysfs GPIO vs GPIO Character Device

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -368,7 +368,7 @@ impl LineHandle {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum EventType {
     RisingEdge,
     FallingEdge,


### PR DESCRIPTION
Minor tweak so we can compare EventType's. Also the older error-chain package was giving a bunch of warnings.