### PR TITLE
Formatting/Documentation Pass on Entire API

### DIFF
--- a/examples/blinky.rs
+++ b/examples/blinky.rs
@@ -7,12 +7,13 @@
 // except according to those terms.
 
 extern crate gpio_cdev;
-#[macro_use] extern crate quicli;
+#[macro_use]
+extern crate quicli;
 
 use gpio_cdev::*;
-use std::time::{Duration, Instant};
-use std::thread::sleep;
 use quicli::prelude::*;
+use std::thread::sleep;
+use std::time::{Duration, Instant};
 
 #[derive(Debug, StructOpt)]
 struct Cli {
@@ -31,7 +32,9 @@ fn do_main(args: Cli) -> errors::Result<()> {
 
     // NOTE: we set the default value to the desired state so
     // setting it separately is not required
-    let handle = chip.get_line(args.line)?.request(RequestFlags::OUTPUT, 1, "readinput")?;
+    let handle = chip
+        .get_line(args.line)?
+        .request(LineRequestFlags::OUTPUT, 1, "readinput")?;
 
     let duration = Duration::from_millis(args.duration_ms);
     let start_time = Instant::now();
@@ -45,11 +48,9 @@ fn do_main(args: Cli) -> errors::Result<()> {
     Ok(())
 }
 
-main!(|args: Cli| {
-    match do_main(args) {
-        Ok(()) => {},
-        Err(e) => {
-            println!("Error: {:?}", e);
-        }
+main!(|args: Cli| match do_main(args) {
+    Ok(()) => {}
+    Err(e) => {
+        println!("Error: {:?}", e);
     }
 });

--- a/examples/driveoutput.rs
+++ b/examples/driveoutput.rs
@@ -7,7 +7,8 @@
 // except according to those terms.
 
 extern crate gpio_cdev;
-#[macro_use] extern crate quicli;
+#[macro_use]
+extern crate quicli;
 
 use gpio_cdev::*;
 use quicli::prelude::*;
@@ -27,7 +28,9 @@ fn do_main(args: Cli) -> errors::Result<()> {
 
     // NOTE: we set the default value to the desired state so
     // setting it separately is not required
-    let _handle = chip.get_line(args.line)?.request(RequestFlags::OUTPUT, args.value, "readinput")?;
+    let _handle =
+        chip.get_line(args.line)?
+            .request(LineRequestFlags::OUTPUT, args.value, "readinput")?;
 
     println!("Output being driven... Enter to exit");
     let mut buf = String::new();
@@ -36,11 +39,9 @@ fn do_main(args: Cli) -> errors::Result<()> {
     Ok(())
 }
 
-main!(|args: Cli| {
-    match do_main(args) {
-        Ok(()) => {},
-        Err(e) => {
-            println!("Error: {:?}", e);
-        }
+main!(|args: Cli| match do_main(args) {
+    Ok(()) => {}
+    Err(e) => {
+        println!("Error: {:?}", e);
     }
 });

--- a/examples/gpioevents.rs
+++ b/examples/gpioevents.rs
@@ -7,7 +7,8 @@
 // except according to those terms.
 
 extern crate gpio_cdev;
-#[macro_use] extern crate quicli;
+#[macro_use]
+extern crate quicli;
 
 use gpio_cdev::*;
 use quicli::prelude::*;
@@ -24,18 +25,20 @@ fn do_main(args: Cli) -> errors::Result<()> {
     let mut chip = Chip::new(args.chip)?;
     let line = chip.get_line(args.line)?;
 
-    for event in line.events(RequestFlags::INPUT, EventRequestFlags::BOTH_EDGES, "gpioevents")? {
+    for event in line.events(
+        LineRequestFlags::INPUT,
+        EventRequestFlags::BOTH_EDGES,
+        "gpioevents",
+    )? {
         println!("{:?}", event?);
     }
 
     Ok(())
 }
 
-main!(|args: Cli| {
-    match do_main(args) {
-        Ok(()) => {},
-        Err(e) => {
-            println!("Error: {:?}", e);
-        }
+main!(|args: Cli| match do_main(args) {
+    Ok(()) => {}
+    Err(e) => {
+        println!("Error: {:?}", e);
     }
 });

--- a/examples/lsgpio.rs
+++ b/examples/lsgpio.rs
@@ -53,11 +53,11 @@ fn main() {
                             flags.push("open-source");
                         }
 
-                       let usage =  if flags.len() > 0 {
+                        let usage = if flags.len() > 0 {
                             format!("[{}]", flags.join(" "))
                         } else {
                             "".to_owned()
-                       };
+                        };
 
                         println!(
                             "\tline {lineno:>3}: {name} {consumer} {usage}",

--- a/examples/readinput.rs
+++ b/examples/readinput.rs
@@ -7,7 +7,8 @@
 // except according to those terms.
 
 extern crate gpio_cdev;
-#[macro_use] extern crate quicli;
+#[macro_use]
+extern crate quicli;
 
 use gpio_cdev::*;
 use quicli::prelude::*;
@@ -22,17 +23,17 @@ struct Cli {
 
 fn do_main(args: Cli) -> errors::Result<()> {
     let mut chip = Chip::new(args.chip)?;
-    let handle = chip.get_line(args.line)?.request(RequestFlags::INPUT, 0, "readinput")?;
+    let handle = chip
+        .get_line(args.line)?
+        .request(LineRequestFlags::INPUT, 0, "readinput")?;
     println!("Value: {:?}", handle.get_value()?);
 
     Ok(())
 }
 
-main!(|args: Cli| {
-    match do_main(args) {
-        Ok(()) => {},
-        Err(e) => {
-            println!("Error: {:?}", e);
-        }
+main!(|args: Cli| match do_main(args) {
+    Ok(()) => {}
+    Err(e) => {
+        println!("Error: {:?}", e);
     }
 });

--- a/examples/tit_for_tat.rs
+++ b/examples/tit_for_tat.rs
@@ -7,12 +7,13 @@
 // except according to those terms.
 
 extern crate gpio_cdev;
-#[macro_use] extern crate quicli;
+#[macro_use]
+extern crate quicli;
 
 use gpio_cdev::*;
 use quicli::prelude::*;
-use std::time::Duration;
 use std::thread::sleep;
+use std::time::Duration;
 
 #[derive(Debug, StructOpt)]
 struct Cli {
@@ -30,12 +31,16 @@ fn do_main(args: Cli) -> errors::Result<()> {
     let mut chip = Chip::new(args.chip)?;
     let input = chip.get_line(args.inputline)?;
     let output = chip.get_line(args.outputline)?;
-    let output_handle = output.request(RequestFlags::OUTPUT, 0, "tit_for_tat")?;
+    let output_handle = output.request(LineRequestFlags::OUTPUT, 0, "tit_for_tat")?;
 
     // To show off the buffering characteristics of the new interface we introduce a delay
     // after each change is handled.  When we fall behind, we will "replay" the input
     // events
-    for event in input.events(RequestFlags::INPUT, EventRequestFlags::BOTH_EDGES, "tit_for_tat")? {
+    for event in input.events(
+        LineRequestFlags::INPUT,
+        EventRequestFlags::BOTH_EDGES,
+        "tit_for_tat",
+    )? {
         let evt = event?;
         println!("{:?}", evt);
         match evt.event_type() {
@@ -53,11 +58,9 @@ fn do_main(args: Cli) -> errors::Result<()> {
     Ok(())
 }
 
-main!(|args: Cli| {
-    match do_main(args) {
-        Ok(()) => {},
-        Err(e) => {
-            println!("Error: {:?}", e);
-        }
+main!(|args: Cli| match do_main(args) {
+    Ok(()) => {}
+    Err(e) => {
+        println!("Error: {:?}", e);
     }
 });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,22 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+//! The `gpio-cdev` crate provides access to the [GPIO character device
+//! ABI](https://www.kernel.org/doc/Documentation/ABI/testing/gpio-cdev).  This API,
+//! stabilized with Linux v4.4, deprecates the legacy sysfs interface to GPIOs that is
+//! planned to be removed from the upstream kernel after
+//! year 2020 (which is coming up quickly).
+//!
+//! This crate attempts to wrap this interface in a moderately direction fashion
+//! while retaining safety and using Rust idioms (where doing so could be mapped
+//! to the underlying abstraction without significant overhead or loss of
+//! functionality).
+//!
+//! For additional context for why the kernel is moving from the sysfs API to the
+//! character device API, please see the main [README on Github].
+//!
+//! [README on Github]: https://github.com/posborne/rust-gpio-cdev
+
 #[macro_use]
 extern crate bitflags;
 #[macro_use]
@@ -24,8 +40,8 @@ use std::ptr;
 use std::slice;
 use std::sync::Arc;
 
-mod ffi;
 pub mod errors;
+mod ffi;
 
 use errors::*;
 
@@ -48,6 +64,28 @@ struct InnerChip {
     pub lines: u32,
 }
 
+/// A GPIO Chip maps to the actual device driver instance in hardware that
+/// one interacts with to interact with individual GPIOs.  Often these chips
+/// map to IP chunks on an SoC but could also be enumerated within the kernel
+/// via something like a PCI or USB bus.
+///
+/// The Linux kernel itself enumerates GPIO character devices at two paths:
+/// 1. `/dev/gpiochipN`
+/// 2. `/sys/bus/gpiochipN`
+///
+/// It is best not to assume that a device will always be enumerated in the
+/// same order (especially if it is connected via a bus).  In order to reliably
+/// find the correct chip, there are a few approaches that one could reasonably
+/// take:
+///
+/// 1. Create a udev rule that will match attributes of the device and
+///    setup a symlink to the device.
+/// 2. Iterate over all available chips using the [`chips()`] call to find the
+///    device with matching criteria.
+/// 3. For simple cases, just using the enumerated path is fine (demo work).  This
+///    is discouraged for production.
+///
+/// [`chips()`]: fn.chips.html
 #[derive(Debug)]
 pub struct Chip {
     inner: Arc<Box<InnerChip>>,
@@ -83,13 +121,15 @@ impl Iterator for ChipIterator {
     }
 }
 
+/// Iterate over all GPIO chips currently present on this system
 pub fn chips() -> Result<ChipIterator> {
     Ok(ChipIterator {
         readdir: read_dir("/dev")?,
     })
 }
+
 impl Chip {
-    /// Open the GPIO Chip at the provided path (/dev/gpiochip<N>)
+    /// Open the GPIO Chip at the provided path (e.g. `/dev/gpiochip<N>`)
     pub fn new<P: AsRef<Path>>(path: P) -> Result<Chip> {
         let f = File::open(path.as_ref())?;
         let mut info: ffi::gpiochip_info = unsafe { mem::uninitialized() };
@@ -114,26 +154,48 @@ impl Chip {
         })
     }
 
+    /// Get the fs path of this character device (e.g. `/dev/gpiochipN`)
     pub fn path(&self) -> &Path {
         self.inner.path.as_path()
     }
 
+    /// The name of the device driving this GPIO chip in the kernel
     pub fn name(&self) -> &str {
         self.inner.name.as_str()
     }
 
+    /// A functional name for this GPIO chip, such as a product number.  Might
+    /// be an empty string.
+    ///
+    /// As an example, the SoC GPIO chip on a Raspberry Pi is "pinctrl-bcm2835"
     pub fn label(&self) -> &str {
         self.inner.label.as_str()
     }
 
+    /// The number of lines/pins indexable through this chip
+    ///
+    /// Not all of these may be usable depending on how the hardware is
+    /// configured/muxed.
     pub fn num_lines(&self) -> u32 {
         self.inner.lines
     }
 
+    /// Get a handle to the GPIO line at a given offset
+    ///
+    /// The actual physical line corresponding to a given offset
+    /// is completely dependent on how the driver/hardware for
+    /// the chip works as well as the associated board layout.
+    ///
+    /// For a device like the NXP i.mx6 SoC GPIO controller there
+    /// are several banks of GPIOs with each bank containing 32
+    /// GPIOs.  For this hardware and driver something like
+    /// `GPIO2_5` would map to offset 37.
     pub fn get_line(&mut self, offset: u32) -> Result<Line> {
         Line::new(self.inner.clone(), offset)
     }
 
+    /// Get an interator over all lines that can be potentially access for this
+    /// chip.
     pub fn lines(&self) -> LineIterator {
         LineIterator {
             chip: self.inner.clone(),
@@ -142,6 +204,7 @@ impl Chip {
     }
 }
 
+/// Iterator over GPIO Lines for a given chip.
 pub struct LineIterator {
     chip: Arc<Box<InnerChip>>,
     idx: u32,
@@ -163,6 +226,17 @@ impl Iterator for LineIterator {
     }
 }
 
+/// Information about and access to a specific GPIO Line
+///
+/// GPIO Lines must be obtained through a parent [`Chip`] and
+/// represent an actual GPIO pin/line accessible via that chip.
+/// Not all accessible lines for a given chip may actually
+/// map to hardware depending on how the board is setup
+/// in the kernel.
+///
+/// Wraps kernel [`struct gpioline_info`].
+///
+/// [`struct gpioline_info`]: https://elixir.bootlin.com/linux/v4.9.127/source/include/uapi/linux/gpio.h#L36
 #[derive(Debug, Clone)]
 pub struct Line {
     chip: Arc<Box<InnerChip>>,
@@ -172,9 +246,13 @@ pub struct Line {
     consumer: Option<String>,
 }
 
-// Line Request Flags
+/// Line Request Flags
+///
+/// Maps to kernel [`GPIOHANDLE_REQUEST_*`] flags.
+///
+/// [`GPIOHANDLE_REQUEST_*`]: https://elixir.bootlin.com/linux/v4.9.127/source/include/uapi/linux/gpio.h#L58
 bitflags! {
-    pub struct RequestFlags: libc::uint32_t {
+    pub struct LineRequestFlags: libc::uint32_t {
         const INPUT = (1 << 0);
         const OUTPUT = (1 << 1);
         const ACTIVE_LOW = (1 << 2);
@@ -183,7 +261,11 @@ bitflags! {
     }
 }
 
-// Event request flags
+/// Event request flags
+///
+/// Maps to kernel [`GPIOEVENT_REQEST_*`] flags.
+///
+/// [`GPIOEVENT_REQUEST_*`]: https://elixir.bootlin.com/linux/v4.9.127/source/include/uapi/linux/gpio.h#L109
 bitflags! {
     pub struct EventRequestFlags: libc::uint32_t {
         const RISING_EDGE = (1 << 0);
@@ -192,7 +274,11 @@ bitflags! {
     }
 }
 
-// Informational Flags
+/// Informational Flags
+///
+/// Maps to kernel [`GPIOLINE_FLAG_*`] flags.
+///
+/// [`GPIOLINE_FLAG_*`]: https://elixir.bootlin.com/linux/v4.9.127/source/include/uapi/linux/gpio.h#L29
 bitflags! {
     pub struct LineFlags: libc::uint32_t {
         const KERNEL = (1 << 0);
@@ -203,6 +289,7 @@ bitflags! {
     }
 }
 
+/// In or Out
 #[derive(Debug, PartialEq)]
 pub enum LineDirection {
     In,
@@ -236,42 +323,62 @@ impl Line {
         })
     }
 
+    /// Refresh the cached line info from the kernel
     pub fn refresh(self) -> Result<Line> {
         Line::new(self.chip, self.offset)
     }
 
+    /// Offset of this line within its parent chip
     pub fn offset(&self) -> u32 {
         self.offset
     }
 
+    /// Name assigned to this chip if assigned
     pub fn name(&self) -> Option<&str> {
         self.name.as_ref().map(|s| s.as_str())
     }
 
+    /// The name of this GPIO line, such as the output pin of the line on the
+    /// chip, a rail or a pin header name on a board, as specified by the gpio
+    /// chip.
     pub fn consumer(&self) -> Option<&str> {
         self.consumer.as_ref().map(|s| s.as_str())
     }
 
+    /// True if the any flags for the device are set (input or output)
     pub fn is_used(&self) -> bool {
         !self.flags.is_empty()
     }
 
+    /// True if this line is being used by something else in the kernel
+    ///
+    /// If another driver or subsystem in the kernel is using the line
+    /// then it cannot be used via the cdev interface. See [relevant kernel code].
+    ///
+    /// [relevant kernel code]: https://elixir.bootlin.com/linux/v4.9.127/source/drivers/gpio/gpiolib.c#L938
     pub fn is_kernel(&self) -> bool {
         self.flags.contains(LineFlags::KERNEL)
     }
 
+    /// True if this line is marked as active low in the kernel
     pub fn is_active_low(&self) -> bool {
         self.flags.contains(LineFlags::ACTIVE_LOW)
     }
 
+    /// True if this line is marked as open drain in the kernel
     pub fn is_open_drain(&self) -> bool {
         self.flags.contains(LineFlags::OPEN_DRAIN)
     }
 
+    /// True if this line is marked as open source in the kernel
     pub fn is_open_source(&self) -> bool {
         self.flags.contains(LineFlags::OPEN_SOURCE)
     }
 
+    /// Get the direction of this GPIO if configured
+    ///
+    /// Lines are considered to be inputs if not explicitly
+    /// marked as outputs in the line info flags by the kernel.
     pub fn direction(&self) -> LineDirection {
         match self.flags.contains(LineFlags::IS_OUT) {
             true => LineDirection::Out,
@@ -279,13 +386,44 @@ impl Line {
         }
     }
 
+    /// Get a handle to this chip's parent
     pub fn chip(&self) -> Chip {
         Chip {
             inner: self.chip.clone(),
         }
     }
 
-    pub fn request(&self, flags: RequestFlags, default: u8, consumer: &str) -> Result<LineHandle> {
+    /// Request access to interact with this line from the kernel
+    ///
+    /// This is similar to the "export" operation present in the sysfs
+    /// API with the key difference that we are also able to configure
+    /// the GPIO with `flags` to specify how the line will be used
+    /// at the time of request.
+    ///
+    /// For an output, the `default` parameter specifies the value
+    /// the line should have when it is configured as an output.  The
+    /// `consumer` string should describe the process consuming the
+    /// pin (this will be truncated to 31 characters if too long).
+    ///
+    /// # Errors
+    ///
+    /// The main source of errors here is if the kernel returns an
+    /// error to the ioctl performing the request here.  This will
+    /// result in an [`Error`] being returned with [`ErrorKind::Io`].
+    ///
+    /// One possible cause for an error here would be if the line is
+    /// already in use.  One can check for this prior to making the
+    /// request using [`is_kernel`].
+    ///
+    /// [`Error`]: errors/struct.Error.html
+    /// [`ErrorKind::Io`]: errors/enum.ErrorKind.html#variant.Io
+    /// [`is_kernel`]: struct.Line.html#method.is_kernel
+    pub fn request(
+        &self,
+        flags: LineRequestFlags,
+        default: u8,
+        consumer: &str,
+    ) -> Result<LineHandle> {
         // prepare the request; the kernel consumes some of these values and will
         // set the fd for us.
         let mut request = ffi::gpiohandle_request {
@@ -313,9 +451,45 @@ impl Line {
         })
     }
 
+    /// Get a blocking iterator over events (state changes) for this Line
+    ///
+    /// This iterator blocks while there is not another event available
+    /// from the kernel for this line matching the subscription criteria
+    /// specified in the `event_flags`.  The line will be configured
+    /// with the specified `handle_flags` and `consumer` label.
+    ///
+    /// Note that as compared with the sysfs interface, the character
+    /// device interface maintains a queue of events in the kernel so
+    /// events may happen (e.g. a line changing state faster than can
+    /// be picked up in userspace in real-time).  These events will be
+    /// returned on the iterator in order with the event containing the
+    /// associated timestamp attached with high precision within the
+    /// kernel (from an ISR for most drivers).
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use gpio_cdev::*;
+    ///
+    /// # use std::io;
+    /// # fn main() -> errors::Result<()> {
+    /// let mut chip = Chip::new("/dev/gpiochip0")?;
+    /// let input = chip.get_line(0)?;
+    ///
+    /// // Show all state changes for this line forever
+    /// for event in input.events(
+    ///     LineRequestFlags::INPUT,
+    ///     EventRequestFlags::BOTH_EDGES,
+    ///     "rust-gpio"
+    /// )? {
+    ///     println!("{:?}", event?);
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn events(
         &self,
-        handle_flags: RequestFlags,
+        handle_flags: LineRequestFlags,
         event_flags: EventRequestFlags,
         consumer: &str,
     ) -> Result<LineEventIterator> {
@@ -342,20 +516,48 @@ impl Line {
     }
 }
 
+/// Handle for interacting with a "requested" line
+///
+/// In order for userspace to read/write the value of a GPIO
+/// it must be requested from the chip using [`Line::request`].
+/// On success, the kernel creates and anonymous file descriptor
+/// for interacting with the requested line.  This structure
+/// is the go-between for callers and that file descriptor.
+///
+/// [`Line::request`]: struct.Line.html#method.request
 #[derive(Debug)]
 pub struct LineHandle {
     line: Line,
-    flags: RequestFlags,
+    flags: LineRequestFlags,
     file: File,
 }
 
 impl LineHandle {
+    /// Request the current state of this Line from the kernel
+    ///
+    /// This call is expected to succeed for both input and output
+    /// pins.  It should be noted, however, that some drivers may
+    /// not be able to give any useful information when the value
+    /// is requested for an output pin.
+    ///
+    /// This value should be 0 or 1 which a "1" representing that
+    /// the line is active.  Usually this means that the line is
+    /// at logic-level high but it could mean the opposite if the
+    /// line has been marked as being ACTIVE_LOW.
     pub fn get_value(&self) -> Result<u8> {
         let mut data: ffi::gpiohandle_data = unsafe { mem::zeroed() };
         let _ = unsafe { ffi::gpiohandle_get_line_values_ioctl(self.file.as_raw_fd(), &mut data)? };
         Ok(data.values[0])
     }
 
+    /// Request that the line be driven to the specified value
+    ///
+    /// The value should be 0 or 1 with 1 representing a request
+    /// to make the line "active".  Usually "active" means
+    /// logic level high unless the line has been marked as ACTIVE_LOW.
+    ///
+    /// Calling `set_value` on a line that is not an output will
+    /// likely result in an error (from the kernel).
     pub fn set_value(&self, value: u8) -> Result<()> {
         let mut data: ffi::gpiohandle_data = unsafe { mem::zeroed() };
         data.values[0] = value;
@@ -363,17 +565,28 @@ impl LineHandle {
         Ok(())
     }
 
+    /// Get the Line information associated with this handle.
     pub fn line(&self) -> &Line {
         &self.line
     }
 }
 
+/// Did the Line rise (go active) or fall (go inactive)?
+///
+/// Maps to kernel [`GPIOEVENT_EVENT_*`] definitions.
+///
+/// [`GPIOEVENT_EVENT_*`]: https://elixir.bootlin.com/linux/v4.9.127/source/include/uapi/linux/gpio.h#L136
 #[derive(Debug, PartialEq)]
 pub enum EventType {
     RisingEdge,
     FallingEdge,
 }
 
+/// Information about a change to the state of a Line
+///
+/// Wraps kernel [`struct gpioevent_data`].
+///
+/// [`struct gpioevent_data`]: https://elixir.bootlin.com/linux/v4.9.127/source/include/uapi/linux/gpio.h#L142
 pub struct LineEvent(ffi::gpioevent_data);
 
 impl std::fmt::Debug for LineEvent {
@@ -388,10 +601,19 @@ impl std::fmt::Debug for LineEvent {
 }
 
 impl LineEvent {
+    /// Best estimate of event occurrence time, in nanoseconds
+    ///
+    /// In most cases, the timestamp for the event is captured
+    /// in an interrupt handler so it should be very accurate.
+    ///
+    /// The nanosecond timestamp value should are captured
+    /// using the CLOCK_REALTIME offsets in the kernel and
+    /// should be compared against CLOCK_REALTIME values.
     pub fn timestamp(&self) -> u64 {
         self.0.timestamp
     }
 
+    /// Was this a rising or a falling edge?
     pub fn event_type(&self) -> EventType {
         if self.0.id == 0x01 {
             EventType::RisingEdge
@@ -401,6 +623,7 @@ impl LineEvent {
     }
 }
 
+/// Blocking iterator over events for a given line
 #[derive(Debug)]
 pub struct LineEventIterator {
     file: File,
@@ -427,11 +650,3 @@ impl Iterator for LineEventIterator {
         }
     }
 }
-
-#[derive(Debug)]
-pub struct LinePoll {
-    line: Line,
-    file: File,
-}
-
-impl LinePoll {}


### PR DESCRIPTION
There are a few minor changes and I ran the latest (as of 1.29.0) `cargo fmt` on the code, but the main thing here is the addition of a healthy number of docs.  Since we map back fairly directly to the kernel in most cases, I included links back to the relevant kernel source in several places.