### PR TITLE
Add multi-line support.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,19 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## 0.1.0 - 2018-09-28
+## v0.2.0 - 2018-12-12
+
+Adds the ability to create a collection of lines from a single chip and read or write those lines simultaneously with a single stystem call.
+ 
+- A new `Lines` object (plural) was added. It is a collection of individual `Line` objects on a single `Chip` which can be read or written simultaneously with a single system call.
+- A `Line` now just contains the reference to the Chip and the offset number. No system call is incurred when one is created.
+- Information about an individual line is now represented by a separate `LineInfo` struct which can be obtained from the function `Line::info()`. This incurs a system call to retrieve the information.
+- Creating a `Line` can't fail unless the caller specifies an offset that is out of range of the chip. 
+- The `LineIterator` can not fail since it checks the offset range. So now its item is just a `Line`, and not `Result<Line>`.
+- There was no longer a need for `Line::refresh()` so it was removed.
+- Since a `Line` object is trivial to create, it is now OK to have `Lines` be a simple collection of `Line` structs.
+
+## v0.1.0 - 2018-09-28
 
 - Initial release of the library with basic operations centered around operating
   on a single line at a time.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "gpio-cdev"
-version = "0.1.0"
-authors = ["Paul Osborne <osbpau@gmail.com>"]
+version = "0.2.0"
+authors = ["Paul Osborne <osbpau@gmail.com>", "Frank Pagliughi <fpagliughi@mindspring.com>"]
 description = "Linux GPIO Character Device Support (/dev/gpiochipN)"
 homepage = "https://github.com/posborne/rust-gpio-cdev"
 repository = "https://github.com/posborne/rust-gpio-cdev"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Add the following to your Cargo.toml
 
 ```
 [dependencies]
-gpio-cdev = "0.1"
+gpio-cdev = "0.2"
 ```
 
 ## Examples

--- a/examples/blinky.rs
+++ b/examples/blinky.rs
@@ -34,7 +34,7 @@ fn do_main(args: Cli) -> errors::Result<()> {
     // setting it separately is not required
     let handle = chip
         .get_line(args.line)?
-        .request(LineRequestFlags::OUTPUT, 1, "readinput")?;
+        .request(LineRequestFlags::OUTPUT, 1, "blinky")?;
 
     let duration = Duration::from_millis(args.duration_ms);
     let start_time = Instant::now();

--- a/examples/lsgpio.rs
+++ b/examples/lsgpio.rs
@@ -31,25 +31,25 @@ fn main() {
                 chip.num_lines()
             );
             for line in chip.lines() {
-                match line {
-                    Ok(line) => {
+                match line.info() {
+                    Ok(info) => {
                         let mut flags = vec![];
 
-                        if line.is_kernel() {
+                        if info.is_kernel() {
                             flags.push("kernel");
                         }
 
-                        if line.direction() == LineDirection::Out {
+                        if info.direction() == LineDirection::Out {
                             flags.push("output");
                         }
 
-                        if line.is_active_low() {
+                        if info.is_active_low() {
                             flags.push("active-low");
                         }
-                        if line.is_open_drain() {
+                        if info.is_open_drain() {
                             flags.push("open-drain");
                         }
-                        if line.is_open_source() {
+                        if info.is_open_source() {
                             flags.push("open-source");
                         }
 
@@ -61,15 +61,16 @@ fn main() {
 
                         println!(
                             "\tline {lineno:>3}: {name} {consumer} {usage}",
-                            lineno = line.offset(),
-                            name = line.name().unwrap_or("unused"),
-                            consumer = line.consumer().unwrap_or("unused"),
+                            lineno = info.line().offset(),
+                            name = info.name().unwrap_or("unused"),
+                            consumer = info.consumer().unwrap_or("unused"),
                             usage = usage,
                         );
                     }
-                    Err(e) => println!("\tError getting line: {:?}", e),
+                    Err(e) => println!("\tError getting line info: {:?}", e),
                 }
             }
+            println!();
         }
     }
 }

--- a/examples/multioutput.rs
+++ b/examples/multioutput.rs
@@ -17,22 +17,35 @@ use quicli::prelude::*;
 struct Cli {
     /// The gpiochip device (e.g. /dev/gpiochip0)
     chip: String,
-    /// The offset of the GPIO line for the provided chip
-    line: u32,
-    /// The value to write
-    value: u8,
+    /// The offset and value of each GPIO line for the provided chip
+    /// in the form "off=<0|1>"
+    line_values: Vec<String>,
 }
 
+// Use like:
+//   muiltioutput /dev/gpiochip0 0=1 1=1 2=0 3=1 4=0
+//
+// to set lines 0, 1, & 3 high
+//              2 & 4 low
+//
 fn do_main(args: Cli) -> errors::Result<()> {
     let mut chip = Chip::new(args.chip)?;
+    let mut offsets = Vec::new();
+    let mut values = Vec::new();
 
-    // NOTE: we set the default value to the desired state so
-    // setting it separately is not required
+    for arg in args.line_values {
+        let lv: Vec<&str> = arg.split("=").collect();
+        offsets.push(lv[0].parse::<u32>().unwrap());
+        values.push(lv[1].parse::<u8>().unwrap());
+    }
+
+    // NOTE: we set the default values to the desired states so
+    // setting them separately is not required
     let _handle =
-        chip.get_line(args.line)?
-            .request(LineRequestFlags::OUTPUT, args.value, "driveoutput")?;
+        chip.get_lines(&offsets)?
+            .request(LineRequestFlags::OUTPUT, &values, "multioutput")?;
 
-    println!("Output being driven... Enter to exit");
+    println!("Output lines being driven... Enter to exit");
     let mut buf = String::new();
     ::std::io::stdin().read_line(&mut buf)?;
 

--- a/examples/multiread.rs
+++ b/examples/multiread.rs
@@ -17,24 +17,17 @@ use quicli::prelude::*;
 struct Cli {
     /// The gpiochip device (e.g. /dev/gpiochip0)
     chip: String,
-    /// The offset of the GPIO line for the provided chip
-    line: u32,
-    /// The value to write
-    value: u8,
+    /// The offset of the GPIO lines for the provided chip
+    lines: Vec<u32>,
 }
 
 fn do_main(args: Cli) -> errors::Result<()> {
     let mut chip = Chip::new(args.chip)?;
-
-    // NOTE: we set the default value to the desired state so
-    // setting it separately is not required
-    let _handle =
-        chip.get_line(args.line)?
-            .request(LineRequestFlags::OUTPUT, args.value, "driveoutput")?;
-
-    println!("Output being driven... Enter to exit");
-    let mut buf = String::new();
-    ::std::io::stdin().read_line(&mut buf)?;
+    let ini_vals = vec![ 0; args.lines.len() ];
+    let handle = chip
+        .get_lines(&args.lines)?
+        .request(LineRequestFlags::INPUT, &ini_vals, "multiread")?;
+    println!("Values: {:?}", handle.get_values()?);
 
     Ok(())
 }

--- a/examples/readall.rs
+++ b/examples/readall.rs
@@ -17,24 +17,15 @@ use quicli::prelude::*;
 struct Cli {
     /// The gpiochip device (e.g. /dev/gpiochip0)
     chip: String,
-    /// The offset of the GPIO line for the provided chip
-    line: u32,
-    /// The value to write
-    value: u8,
 }
 
 fn do_main(args: Cli) -> errors::Result<()> {
     let mut chip = Chip::new(args.chip)?;
-
-    // NOTE: we set the default value to the desired state so
-    // setting it separately is not required
-    let _handle =
-        chip.get_line(args.line)?
-            .request(LineRequestFlags::OUTPUT, args.value, "driveoutput")?;
-
-    println!("Output being driven... Enter to exit");
-    let mut buf = String::new();
-    ::std::io::stdin().read_line(&mut buf)?;
+    let ini_vals = vec![ 0; chip.num_lines() as usize ];
+    let handle = chip
+        .get_all_lines()?
+        .request(LineRequestFlags::INPUT, &ini_vals, "multiread")?;
+    println!("Values: {:?}", handle.get_values()?);
 
     Ok(())
 }

--- a/examples/readall.rs
+++ b/examples/readall.rs
@@ -24,7 +24,7 @@ fn do_main(args: Cli) -> errors::Result<()> {
     let ini_vals = vec![ 0; chip.num_lines() as usize ];
     let handle = chip
         .get_all_lines()?
-        .request(LineRequestFlags::INPUT, &ini_vals, "multiread")?;
+        .request(LineRequestFlags::INPUT, &ini_vals, "readall")?;
     println!("Values: {:?}", handle.get_values()?);
 
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -717,7 +717,7 @@ impl Lines {
         self.lines.len()
     }
 
-    /// Request access to interact with this line from the kernel
+    /// Request access to interact with these lines from the kernel
     ///
     /// This is similar to the "export" operation present in the sysfs
     /// API with the key difference that we are also able to configure
@@ -725,7 +725,7 @@ impl Lines {
     /// at the time of request.
     ///
     /// For an output, the `default` parameter specifies the value
-    /// the line should have when it is configured as an output.  The
+    /// each line should have when it is configured as an output.  The
     /// `consumer` string should describe the process consuming the
     /// line (this will be truncated to 31 characters if too long).
     ///
@@ -735,7 +735,7 @@ impl Lines {
     /// error to the ioctl performing the request here.  This will
     /// result in an [`Error`] being returned with [`ErrorKind::Io`].
     ///
-    /// One possible cause for an error here would be if the line is
+    /// One possible cause for an error here would be if the lines are
     /// already in use.  One can check for this prior to making the
     /// request using [`is_kernel`].
     ///


### PR DESCRIPTION
This is an initial attempt at #3.

This adds a `Lines` struct which, internally is just a Vec of `Lines` that were obtained from one `Chip` using `get_lines()` or `get_all_lines()`. On `request()` a `MultiLineHandle` is returned which can be used to get or set multiple lines with a single ioctl().

Some of the code is now a bit redundant. Down the road we could possibly implement a LineHandle as a MultiLineHandle with only a single line. Something like that. But before proceeding, I thought it best to get feedback on the overall line of attack here. 